### PR TITLE
Let kaospilot handle the cron logging

### DIFF
--- a/server.js
+++ b/server.js
@@ -39,9 +39,30 @@ loader.load('./plugins/**/plugin.js', function (plugin, filename) {
   }
 });
 
+// Function to handle logging when a cron run is done running.
+var cronRunDone = function (plugin) {
+  return function (err) {
+    var meta = { plugin: plugin.label };
+
+    if (err) {
+      kaospilot.log({
+        level: 'error',
+        msg: err,
+        meta: meta
+      });
+    }
+    else {
+      kaospilot.log({
+        msg: 'Plugin cron run completed.',
+        meta: meta
+      });
+    }
+  };
+};
+
 // Creates a new cron task for each plugin found.
 var initialize = function() {
   for (var i = 0; i < plugins.length; i++) {
-    new CronJob(plugins[i].cron, plugins[i].pilot, null, true);
+    new CronJob(plugins[i].cron, plugins[i].pilot, cronRunDone(plugins[i]), true);
   }
 };


### PR DESCRIPTION
With this change the plugins pilot method can call a callback function when done and supply it with errors to be logged if any errors. If the callback does not recieve any errors the cron run will be considered a success.

**Example**

```
exports.pilot = function (callback) {
  // Perform some action.
  processSomeData(data, function done(err) {
    // Processing is complete, execute the callback function and supply it with the error variable, if there were any errors kaospilot will log them.
    callback(err);
  });
}
```